### PR TITLE
Fix the return keys of the getDeviceLossAndLatencyHistory operation

### DIFF
--- a/openapi/spec2.json
+++ b/openapi/spec2.json
@@ -1750,22 +1750,22 @@
             "examples": {
               "application/json": [
                 {
-                  "startTime": "2018-10-09T22:18:27Z",
-                  "endTime": "2018-10-09T22:19:27Z",
+                  "startTs": "2018-10-09T22:18:27Z",
+                  "endTs": "2018-10-09T22:19:27Z",
                   "lossPercent": 5.23,
                   "latencyMs": 324.12,
                   "goodput": 1493
                 },
                 {
-                  "startTime": "2018-10-09T22:19:27Z",
-                  "endTime": "2018-10-09T22:20:27Z",
+                  "startTs": "2018-10-09T22:19:27Z",
+                  "endTs": "2018-10-09T22:20:27Z",
                   "lossPercent": 1.0,
                   "latencyMs": 43.0,
                   "goodput": 2567
                 },
                 {
-                  "startTime": "2018-10-09T22:20:27Z",
-                  "endTime": "2018-10-09T22:21:27Z",
+                  "startTs": "2018-10-09T22:20:27Z",
+                  "endTs": "2018-10-09T22:21:27Z",
                   "lossPercent": 0.01,
                   "latencyMs": 44.02,
                   "goodput": 7899


### PR DESCRIPTION
The documentation stated that the return keys were `startTime` and` endTime`, but in reality it is `startTs` and` endTs`﻿
