### PR TITLE
fix: organization response properties

### DIFF
--- a/openapi/spec2.json
+++ b/openapi/spec2.json
@@ -38035,7 +38035,62 @@
           "201": {
             "description": "Successful operation",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Organization ID"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Organization name"
+                },
+                "url": {
+                  "type": "string",
+                  "description": "Organization URL"
+                },
+                "api": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Enable API access"
+                    }
+                  },
+                  "description": "API related settings"
+                },
+                "licensing": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string",
+                      "enum": [
+                        "co-term",
+                        "per-device",
+                        "subscription"
+                      ],
+                      "description": "Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'."
+                    }
+                  },
+                  "description": "Licensing related settings"
+                },
+                "cloud": {
+                  "type": "object",
+                  "properties": {
+                    "region": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Name of region"
+                        }
+                      },
+                      "description": "Region info"
+                    }
+                  },
+                  "description": "Data for this organization"
+                }
+              }
             },
             "examples": {
               "application/json": {
@@ -38199,7 +38254,62 @@
           "200": {
             "description": "Successful operation",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Organization ID"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Organization name"
+                },
+                "url": {
+                  "type": "string",
+                  "description": "Organization URL"
+                },
+                "api": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Enable API access"
+                    }
+                  },
+                  "description": "API related settings"
+                },
+                "licensing": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string",
+                      "enum": [
+                        "co-term",
+                        "per-device",
+                        "subscription"
+                      ],
+                      "description": "Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'."
+                    }
+                  },
+                  "description": "Licensing related settings"
+                },
+                "cloud": {
+                  "type": "object",
+                  "properties": {
+                    "region": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Name of region"
+                        }
+                      },
+                      "description": "Region info"
+                    }
+                  },
+                  "description": "Data for this organization"
+                }
+              }
             },
             "examples": {
               "application/json": {


### PR DESCRIPTION

**Reason for PR**
This is a minor change meant to ease development for generating code from the Meraki OpenAPI spec. I believe that schema response objects are on the road map, but if this isn't a duplicate effort I'll keep updating them.

**Affected Resource**
 "/organizations/{organizationId}"  (POST & PUT)

**Exact Change**
Copied the organization `get/responses/200/schema/properties`  response object schema  to the corresponding put & post methods.