### PR TITLE
Create action to publish OASv2 GA docs

### DIFF
--- a/.github/workflows/publish-ga-release-oas.yml
+++ b/.github/workflows/publish-ga-release-oas.yml
@@ -1,9 +1,9 @@
-name: Publish beta OAS with weekly pre-release version update
+name: Publish GA OAS with minor version update
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 12 8-31 * 3'
+    - cron: '0 12 1-7 * 3'
 
 jobs:
   publish:
@@ -11,24 +11,24 @@ jobs:
     steps:
     - uses: actions/checkout@master
       with:
-        ref: "v1-beta"
+        ref: "master"
     - name: Read from AWS bucket
       run: |
         aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws configure set region ${{ secrets.AWS_REGION }}
         aws s3 sync ${{ secrets.AWS_S3_BUCKET }} ./openapi
-        mv openapi/oas2_beta.json openapi/spec2.json
-        mv openapi/oas3_beta.json openapi/spec3.json
-        rm openapi/oas*_ga.json
-    - name: Get latest pre-release version
+        mv openapi/oas2_ga.json openapi/spec2.json
+        rm openapi/oas*_beta.json
+        rm openapi/oas3_ga.json
+    - name: Get latest GA version
       id: current-version
       uses: cardinalby/git-get-release-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         latest: true
-        prerelease: true
+        prerelease: false
     - name: Strip v prefix from version
       id: sanitized-prefix
       run: |
@@ -40,9 +40,10 @@ jobs:
       uses: HardNorth/github-version-generate@v1.3.0
       with:
         version: ${{ steps.sanitized-prefix.outputs.SANITIZED_PREFIX }}
+        next-version-increment-minor: true
     - name: Set new version
       id: new-version
-      run: echo "NEW_VERSION=v${{ env.CURRENT_VERSION_MAJOR }}.${{ env.CURRENT_VERSION_MINOR }}.${{ env.CURRENT_VERSION_PATCH }}-${{ env.NEXT_VERSION_PRERELEASE }}" >> $GITHUB_ENV
+      run: echo "NEW_VERSION=v${{ env.CURRENT_VERSION_MAJOR }}.${{ env.NEXT_VERSION_MINOR }}.0" >> $GITHUB_ENV
     - name: Update OAS docs with new version
       uses: jacobtomlinson/gha-find-replace@v2
       with:
@@ -54,14 +55,14 @@ jobs:
       uses: EndBug/add-and-commit@v9
       with:
         add: openapi/*
-        new_branch: "v1-beta"
+        new_branch: "master"
         tag: "${{ env.NEW_VERSION }}"
         message: "API version ${{ env.NEW_VERSION }}"
     - name: Create release
       uses: ncipollo/release-action@v1
       with:
         tag: "${{ env.NEW_VERSION }}"
-        prerelease: true
+        prerelease: false
         artifacts: "${{ env.NEW_VERSION }}.tar.gz,${{ env.NEW_VERSION }}.zip"
         skipIfReleaseExists: true
         body: "API version ${{ env.NEW_VERSION }}"

--- a/.github/workflows/publish-pre-release-minor-version-oas.yml
+++ b/.github/workflows/publish-pre-release-minor-version-oas.yml
@@ -1,9 +1,9 @@
-name: Publish OAS with monthly pre-release minor version update
+name: Publish beta OAS with monthly pre-release minor version update
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 12 1-7 * 3"
+    - cron: '0 12 1-7 * 3'
 
 jobs:
   publish:


### PR DESCRIPTION
Re-reverting this with single quotes for cron tabs. I doubt it fixes it but not sure what else to try at this point as the scheduled actions are running at the wrong times.

This PR creates three actions:
- One that runs weekly (except for first week of month) to publish a new pre-release release (with pre-release version bumped) with updated spec2.json and spec3.json
- One that runs monthly (first Wednesday of the month) to publish a new pre-release release (with minor version bumped) with updated spec2.json and spec3.json
- One that runs weekly (on every Wednesday) to publish a new GA release (with minor version bumped) with updated spec2.json and spec3.json

Both of these jobs can also be triggered manually.

Both of these are pulling from our AWS s3 bucket that house the latest version of our OAS docs