### PR TITLE
allow actions to be run manually

### DIFF
--- a/.github/workflows/publish-ga-release-oas.yml
+++ b/.github/workflows/publish-ga-release-oas.yml
@@ -2,6 +2,12 @@ name: Publish GA OAS with minor version update
 
 on:
   workflow_dispatch:
+    inputs:
+      override_schedule:
+        description: "Override the release schedule?"
+        required: true
+        type: boolean
+        default: false
   schedule:
     - cron: '0 12 1-7 * 3'
 
@@ -22,7 +28,7 @@ jobs:
           fi
   publish:
     needs: check
-    if: needs.check.outputs.should-continue == 'yes'
+    if: inputs.override_schedule || needs.check.outputs.should-continue == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/publish-pre-release-minor-version-oas.yml
+++ b/.github/workflows/publish-pre-release-minor-version-oas.yml
@@ -2,6 +2,12 @@ name: Publish beta OAS with monthly pre-release minor version update
 
 on:
   workflow_dispatch:
+    inputs:
+      override_schedule:
+        description: "Override the release schedule?"
+        required: true
+        type: boolean
+        default: false
   schedule:
     - cron: '0 12 1-7 * 3'
 
@@ -22,7 +28,7 @@ jobs:
           fi
   publish:
     needs: check
-    if: needs.check.outputs.should-continue == 'yes'
+    if: inputs.override_schedule || needs.check.outputs.should-continue == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/publish-pre-release-oas.yml
+++ b/.github/workflows/publish-pre-release-oas.yml
@@ -2,6 +2,12 @@ name: Publish beta OAS with weekly pre-release version update
 
 on:
   workflow_dispatch:
+    inputs:
+      override_schedule:
+        description: "Override the release schedule?"
+        required: true
+        type: boolean
+        default: false
   schedule:
     - cron: "0 12 8-31 * 3"
 
@@ -22,7 +28,7 @@ jobs:
           fi
   publish:
     needs: check
-    if: needs.check.outputs.should-continue == 'yes'
+    if: inputs.override_schedule || needs.check.outputs.should-continue == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
This adds a checkbox when manually running the jobs to allow for overriding the standard schedules for each job